### PR TITLE
fixed picom bug

### DIFF
--- a/.config/i3/config
+++ b/.config/i3/config
@@ -363,7 +363,7 @@ for_window [class=TelegramDesktop] focus
 ## current backends
 
 #exec_always --no-startup-id picom --experimental-backends -b
-exec_always --no-startup-id picom --experimental-backends -b --animations --animation-window-mass 0.5 --animation-for-open-window zoom --animation-stiffness 350 &
+exec_always --no-startup-id picom --experimental-backends -b
 
 ## previous working config
 


### PR DESCRIPTION
all picom issues resolved, while executing picom at the start , icorrect flags were used which overode the correct flags in the config  , so basically removing the flags from the startup command fixed the issue.